### PR TITLE
Move REGION and BUCKET to .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ SEGMENT_DURATION=10
 SAMPLING_RATE=48000
 
 BUCKET_TYPE=dev
-BUCKET=YourBucketName
+BUCKET_STREAMING=YourStreamingBucketName
+BUCKET_ARCHIVE=YourArchiveBucketName
 REGION=YourAWSRegion
  
 SYSLOG_URL=syslog+tls://syslog-a.logdna.com:YourLogDNAPort

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ CHANNELS=2
 FLAC_DURATION=30
 SEGMENT_DURATION=10
 SAMPLING_RATE=48000
+
 BUCKET_TYPE=dev
+BUCKET=YourBucketName
+REGION=YourAWSRegion
  
 SYSLOG_URL=syslog+tls://syslog-a.logdna.com:YourLogDNAPort
 SYSLOG_STRUCTURED_DATA='logdna@YourLogDNAnumber key="YourLogDNAKey" tag="docker"
@@ -48,9 +51,11 @@ SYSLOG_STRUCTURED_DATA='logdna@YourLogDNAnumber key="YourLogDNAKey" tag="docker"
 * CHANNELS indicates the number of audio channels to expect (1 or 2). 
 * FLAC_DURATION is the amount of seconds you want in each archvied lossless file. 
 * SEGMENT_DURATION is the amount of seconds you want in each streamed lossy segment.
-* SAMPLING_RATE is the hardware sampling rate of the pi sound card.  Allowed values are 48000, 96000 and 19200.  RPI4 recommended for 96000 and 19200 
-* NODE_LOOPBACK should be set to true to loop input to local output
-* BUCKET_TYPE should be dev or prod depending upon which orcasound aws bucket you are streaming to
+* SAMPLING_RATE is the hardware sampling rate of the pi sound card.  Allowed values are 48000, 96000 and 19200.  RPI4 recommended for 96000 and 19200 .
+* NODE_LOOPBACK should be set to true to loop input to local output.
+* BUCKET_TYPE should be dev or prod depending upon which orcasound aws bucket you are streaming to.
+* BUCKET is the name of your AWS S3 bucket.
+* REGION is the region of your AWS S3 bucket. (e.g. 'us-west-2')
 
 ## Running local tests
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ SYSLOG_STRUCTURED_DATA='logdna@YourLogDNAnumber key="YourLogDNAKey" tag="docker"
 * SAMPLING_RATE is the hardware sampling rate of the pi sound card.  Allowed values are 48000, 96000 and 19200.  RPI4 recommended for 96000 and 19200 .
 * NODE_LOOPBACK should be set to true to loop input to local output.
 * BUCKET_TYPE should be dev or prod depending upon which orcasound aws bucket you are streaming to.
-* BUCKET is the name of your AWS S3 bucket.
+* BUCKET_STREAMING is the name of your AWS S3 streaming bucket. Only applies if BUCKET_TYPE=custom.
+* ARCHIVE is the name of your AWS S3 archive bucket. Only applies if BUCKET_TYPE=custom.
 * REGION is the region of your AWS S3 bucket. (e.g. 'us-west-2')
 
 ## Running local tests

--- a/stream.sh
+++ b/stream.sh
@@ -27,7 +27,7 @@ fi
 #  Setup jack 
 echo @audio - memlock 256000 >> /etc/security/limits.conf
 echo @audio - rtprio 75 >> /etc/security/limits.co
-JACK_NO_AUDIO_RESERVATION=1 jackd -t 2000 -P 75 -d alsa -d hw:pisound -r $SAMPLE_RATE -p 1024 -n 10 -s &
+JACK_NO_AUDIO_RESERVATION=1 jackd -t 2000 -P 75 -d alsa -d hw:$AUDIO_HW_ID -r $SAMPLE_RATE -p 1024 -n 10 -s &
 
 #### Generate stream segments and manifests, and/or lossless archive
 

--- a/upload_flac_s3.py
+++ b/upload_flac_s3.py
@@ -47,12 +47,19 @@ handler.setFormatter(formatter)
 
 log.addHandler(handler)
 
-BUCKET = os.environ["BUCKET"]
+BUCKET = ""
 if "BUCKET_TYPE" in os.environ:
     if(os.environ["BUCKET_TYPE"] == "prod"):
+        print("using production bucket")
         BUCKET = 'archive-orcasound-net'
+    elif (os.environ["BUCKET_TYPE"] == "custom"):
+        print("using custom bucket")
+        BUCKET = os.environ["BUCKET_ARCHIVE"]
     else:
-        log.debug("flac files bucket ", BUCKET)
+        print("using dev bucket")
+        BUCKET = "dev-archive-orcasound-net"
+        
+    log.debug("archive bucket set to ", BUCKET)
 
 
 def s3_copy_file(path, filename):

--- a/upload_flac_s3.py
+++ b/upload_flac_s3.py
@@ -33,7 +33,7 @@ PATH = os.path.join(BASEPATH, "flac")
 # s3.Bucket(name='dev-streaming-orcasound-net') // hls 
 
 
-REGION = 'us-west-2'
+REGION = os.environ["REGION"]
 LOGLEVEL = logging.DEBUG
 
 log = logging.getLogger(__name__)
@@ -47,12 +47,12 @@ handler.setFormatter(formatter)
 
 log.addHandler(handler)
 
-BUCKET = 'dev-archive-orcasound-net'
+BUCKET = os.environ["BUCKET"]
 if "BUCKET_TYPE" in os.environ:
     if(os.environ["BUCKET_TYPE"] == "prod"):
         BUCKET = 'archive-orcasound-net'
     else:
-        log.debug("flac files bucket dev-archive-orcasound-net")
+        log.debug("flac files bucket ", BUCKET)
 
 
 def s3_copy_file(path, filename):

--- a/upload_s3.py
+++ b/upload_s3.py
@@ -47,14 +47,18 @@ handler.setFormatter(formatter)
 
 log.addHandler(handler)
 
-BUCKET = os.environ["BUCKET"]
+BUCKET = ""
 if "BUCKET_TYPE" in os.environ:
     if(os.environ["BUCKET_TYPE"] == "prod"):
         print("using production bucket")
         BUCKET = 'streaming-orcasound-net'
+    elif (os.environ["BUCKET_TYPE"] == "custom"):
+        print("using custom bucket")
+        BUCKET = os.environ["BUCKET_STREAMING"]
     else:
-        print("using dev bucket")
-        log.debug("hls bucket set to ", BUCKET)
+        BUCKET = "dev-streaming-orcasound-net"
+
+    log.debug("hls bucket set to ", BUCKET)
 
 def s3_copy_file(path, filename):
     log.debug('uploading file '+filename+' from '+path+' to bucket '+BUCKET)

--- a/upload_s3.py
+++ b/upload_s3.py
@@ -33,7 +33,7 @@ PATH = os.path.join(BASEPATH, "hls")
 # s3.Bucket(name='dev-streaming-orcasound-net') // hls 
 
         
-REGION = 'us-west-2'
+REGION = os.environ["REGION"]
 LOGLEVEL = logging.DEBUG
 
 log = logging.getLogger(__name__)
@@ -47,14 +47,14 @@ handler.setFormatter(formatter)
 
 log.addHandler(handler)
 
-BUCKET = 'dev-streaming-orcasound-net'
+BUCKET = os.environ["BUCKET"]
 if "BUCKET_TYPE" in os.environ:
     if(os.environ["BUCKET_TYPE"] == "prod"):
         print("using production bucket")
         BUCKET = 'streaming-orcasound-net'
     else:
         print("using dev bucket")
-        log.debug("hls bucket set to dev-streaming-orcasound-net")
+        log.debug("hls bucket set to ", BUCKET)
 
 def s3_copy_file(path, filename):
     log.debug('uploading file '+filename+' from '+path+' to bucket '+BUCKET)


### PR DESCRIPTION
The REGION and BUCKET variables are hard-coded into the python upload scripts. Moving these to the .env would make development easier in the future. The stream script also looks for the $AUDIO_HW_ID in the .env rather than always using the hardcoded pisound device. I've updated the example .env in the README to reflect these changes.