### PR TITLE
typo fix on 'README.md' (Line 13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We also aspire to use open source software as much as possible. We rely heavily 
 
 ## Getting Started
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See the deployment section (below) for notes on how to deploy the project on a live system like [live.orcaound.net](https://live.orcaound.net).
+These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See the deployment section (below) for notes on how to deploy the project on a live system like [live.orcasound.net](https://live.orcasound.net).
 
 If you want to set up your hardware to host a hydrophone within the Orcasound network, take a look at [how to join Orcasound](http://www.orcasound.net/join/) and [our prototype built from a Raspberry Pi3b with the Pisound Hat](http://www.orcasound.net/2018/04/27/orcasounds-new-live-audio-solution-from-hydrophone-to-headphone-with-a-raspberry-pi-computer-and-hls-dash-streaming-software/).
 


### PR DESCRIPTION
Fixed broken link by changing 'https://live.orcaound.net' to 'https://live.orcasound.net' on the 'README.md' file.