### PR TITLE
Various fixes to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 The `orcanode` software repository contains audio tools and scripts for capturing, reformatting, transcoding and uploading audio data at each node of a network. Orcanode live-streaming should work on Intel (amd64) or Raspberry Pi (arm32v7) platforms using any soundcard.  The most common hardware used by Orcasound is the [Pisound HAT](https://blokas.io/pisound/) on a Raspberry Pi (3B+ or 4) single-board computer.
 
-There is a `base` set of tools and a couple of specific projects in the `node` and `mseed` directories. The node directory is for new locations streaming within the Orcasound listening network (primary nodes).
+There is a `base` set of tools and a couple of specific projects in the `node` and `mseed` directories. The `node` directory is for new locations streaming within the Orcasound listening network (primary nodes).
 
-The mseed directory has code for converting audio data in the mseed format to the live-streaming audio format used by primary nodes. This conversion code is mainly used for audio data collected by the [Ocean Observatories Initiative or OOI](https://oceanobservatories.org/ "OOI") network.  See the README in the `mseed` directory for more info. Transcoding from other audio formats should likely go in new directories by encoding scheme, similar to the mseed directory... 
+The `mseed` directory has code for converting audio data in the mseed format to the live-streaming audio format used by primary nodes. This conversion code is mainly used for audio data collected by the [Ocean Observatories Initiative or OOI](https://oceanobservatories.org/ "OOI") network.  See the README in the `mseed` directory for more info. Transcoding from other audio formats should likely go in new directories by encoding scheme, similar to the mseed directory... 
 
 You can also gain some bioacoustic context for the project in the [orcanode wiki](https://github.com/orcasound/orcanode/wiki).
 
@@ -12,23 +12,23 @@ You can also gain some bioacoustic context for the project in the [orcanode wiki
 
 This code was developed for live-streaming from source nodes in the [Orcasound](http://orcasound.net) hydrophone network (WA, USA). Thus, the repository names begin with "orca"! Our primary motivation is to make it easy for community scientists to listen for whales via the [Orcasound web app](https://live.orcasound.net) using their favorite device/OS/browser.
 
-We also aspire to use open source software as much as possible. We rely heavily on [FFmpeg](https://www.ffmpeg.org/). One of our long-term goals is to stream lossless [FLAC](https://xiph.org/flac/)-encoded audio within [DASH](https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP) segments to a player that works optimally on as many listening devices as possible. For now (2018-2023) we have found the best end-to-end performance across the broadest range of web browsers is acheived by streaming AAC-encoded audio within [HLS](https://developer.apple.com/streaming/) segments. 
+We also aspire to use open source software as much as possible. We rely heavily on [FFmpeg](https://www.ffmpeg.org/). One of our long-term goals is to stream lossless [FLAC](https://xiph.org/flac/)-encoded audio within [DASH](https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP) segments to a player that works optimally on as many listening devices as possible. For now (2018-2024) we have found the best end-to-end performance across the broadest range of web browsers is acheived by streaming AAC-encoded audio within [HLS](https://developer.apple.com/streaming/) segments. 
 
 ## Getting Started
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See the deployment section (below) for notes on how to deploy the project on a live system like [live.orcasound.net](https://live.orcasound.net).
+These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See the [deployment](#deployment) section for notes on how to deploy the project on a live system like [live.orcasound.net](https://live.orcasound.net).
 
 If you want to set up your hardware to host a hydrophone within the Orcasound network, take a look at [how to join Orcasound](http://www.orcasound.net/join/) and [our prototype built from a Raspberry Pi with the Pisound ADC HAT](http://www.orcasound.net/2018/04/27/orcasounds-new-live-audio-solution-from-hydrophone-to-headphone-with-a-raspberry-pi-computer-and-hls-dash-streaming-software/).
 
-The general scheme is to acquire audio data from a sound card within a Docker container via ALSA or Jack and FFmpeg, and then stream the audio data with minimal latency to cloud-based storage (as of Oct 2021, we use AWS S3 buckets). Errors/etc are logged to LogDNA via a separate Docker container.
+The general scheme is to acquire audio data from a sound card within a Docker container via ALSA or Jack and FFmpeg, and then stream the audio data with minimal latency to cloud-based storage (as of Oct 2024, we use AWS S3 buckets). Errors, etc. are logged to [Mezmo](https://www.mezmo.com/) via a separate Docker container.
 
 ### Prerequisites
 
-An ARM or X86 device with a sound card (or other audio input devices) connected to the Internet (via wireless network or ethernet cable) that has [Docker-compose](https://docs.docker.com/compose/install/) installed and an AWS account with some S3 buckets set up.
+An Arm or x86 device with a sound card (or other audio input device) connected to the Internet (via wireless network or ethernet cable) that has [Docker-compose](https://docs.docker.com/compose/install/) installed and an AWS account with some S3 buckets set up.
 
 ### Installing
 
-Create a base docker image for your architecture by running the script in /base/rpi or /base/amd64 as appropriate.  You will need to create a .env file as appropriate for your projects.  Common to to all projects are the need for AWS keys
+Create a base docker image for your architecture by running the script in `orcanode/base/rpi` or `orcanode/base/amd64` as appropriate.  You will need to create a `orcanode/node/.env` file as appropriate for your projects.  Common to to all projects is the need for AWS keys
 
 ```
 AWSACCESSKEYID=YourAWSaccessKey
@@ -38,13 +38,13 @@ SYSLOG_URL=syslog+tls://syslog-a.logdna.com:YourLogDNAPort
 SYSLOG_STRUCTURED_DATA='logdna@YourLogDNAnumber key="YourLogDNAKey" tag="docker"
 ```
 
-(You can request keys via the #hydrophone-nodes channel in the Orcasound Slack. As of October, 2023, we are continuing to use AWS S3 for storage and LogDNA for live-logging and troubleshooting.)
+(You can request keys via the [#hydrophone-nodes channel in the Orcasound Zulip](https://orcasound.zulipchat.com/#narrow/channel/437036-hydrophone-nodes). As of October, 2024, we are continuing to use AWS S3 for storage and Mezmo for live-logging and troubleshooting.)
 
-Here are explanations of some of the .env fields:
+Here are explanations of some of the `.env` fields:
 
-* NODE_NAME should indicate your device and it's location, ideally in the form `device_location` (e.g. we call our Raspberry Pi staging device in Seattle `rpi_seattle`. 
+* NODE_NAME should indicate your device and it's location, ideally in the form `device_location` (e.g., we call our Raspberry Pi staging device in Seattle `rpi_seattle`. 
 * NODE_TYPE determines what audio data formats will be generated and transferred to their respective AWS buckets. 
-* AUDIO_HW_ID is the card, device providing the audio data. Note: you can find your sound device by using the command "arecord -l".  For Raspberry Pi hardware with pisound just use AUDIO_HW_ID=pisound
+* AUDIO_HW_ID is the card, device providing the audio data. Note: you can find your sound device by using the command `arecord -l`.  For Raspberry Pi hardware with pisound just use AUDIO_HW_ID=pisound
 * CHANNELS indicates the number of audio channels to expect (1 or 2). 
 * FLAC_DURATION is the amount of seconds you want in each archived lossless file. 
 * SEGMENT_DURATION is the amount of seconds you want in each streamed lossy segment.
@@ -76,7 +76,7 @@ Here are explanations of some of the .env fields:
 
 ## Running local tests
 
-In the repository directory (where you also put your .env file) first copy the compose file you want to docker-compose.yml.  For example if you are raspberry pi and you want to use the prebuilt image then copy docker-compose.rpi-pull.yml to docker-compose.  Then run `docker-compose up -d`. Watch what happens using `htop`. If you want to verify files are being written to /tmp or /mnt directories, get the name of your streaming service using `docker-compose ps` (in this case `orcanode_streaming_1`) and then do `docker exec -it orcanode_streaming_1 /bin/bash` to get a bash shell within the running container.
+In the `node` directory (where you also put your .env file) first copy the compose file you want to `docker-compose.yml`.  For example, if you have a raspberry pi and you want to use the prebuilt image then copy `docker-compose.rpi-pull.yml` to `docker-compose.yml`.  Then run `docker-compose up -d`. Watch what happens using `htop`. If you want to verify files are being written to the `/tmp` or `/mnt` directories, get the name of your streaming service using `docker-compose ps` (in this case `orcanode_streaming_1`) and then do `docker exec -it orcanode_streaming_1 /bin/bash` to get a bash shell within the running container.
 
 ## Running an end-to-end test
 
@@ -90,11 +90,11 @@ For end-to-end tests of Orcasound nodes, this schematic describes how sources ma
 
 ![Schematic of Orcasound source-subdomain mapping](http://orcasound.net/img/orcasound-app/Orcasound-software-evolution-model.png "Orcasound software evolution model")
 
-([Google draw source](https://drive.google.com/file/d/1YFTAQPqgtcTl6ubac0mgyQ7fvg0BZqzH/view?usp=sharing) and [archived schematics](https://orcasound.net/img/orcasound-app/)) -- and you can monitor your development stream via the web-app using this URL structure:
+([Google draw source](https://drive.google.com/file/d/1YFTAQPqgtcTl6ubac0mgyQ7fvg0BZqzH/view?usp=sharing) and [archived schematics](https://orcasound.net/img/orcasound-app/)) -- and you can monitor your development stream via the web app using this URL structure:
 
 ```dev.orcasound.net/dynamic/node_name``` 
 
-For example, with node_name = rpi_orcasound_lab the test URL would be [dev.orcasound.net/dynamic/rpi_orcasound_lab](http://dev.orcasound.net/dynamic/rpi_orcasound_lab).
+For example, with `NODE_NAME=rpi_orcasound_lab` the test URL would be [dev.orcasound.net/dynamic/rpi_orcasound_lab](http://dev.orcasound.net/dynamic/rpi_orcasound_lab).
 
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ You can also gain some bioacoustic context for the project in the [orcanode wiki
 
 This code was developed for live-streaming from source nodes in the [Orcasound](http://orcasound.net) hydrophone network (WA, USA). Thus, the repository names begin with "orca"! Our primary motivation is to make it easy for community scientists to listen for whales via the [Orcasound web app](https://live.orcasound.net) using their favorite device/OS/browser.
 
-We also aspire to use open source software as much as possible. We rely heavily on [FFmpeg](https://www.ffmpeg.org/). One of our long-term goals is to stream lossless [FLAC](https://xiph.org/flac/)-encoded audio within [DASH](https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP) segments to a player that works optimally on as many listening devices as possible. For now (2018-2024) we have found the best end-to-end performance across the broadest range of web browsers is acheived by streaming AAC-encoded audio within [HLS](https://developer.apple.com/streaming/) segments. 
+We also aspire to use open source software as much as possible. We rely heavily on [FFmpeg](https://www.ffmpeg.org/). One of our long-term goals is to stream lossless [FLAC](https://xiph.org/flac/)-encoded audio within [DASH](https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP) segments to a player that works optimally on as many listening devices as possible. For now (2018-2025) we have found the best end-to-end performance across the broadest range of web browsers is acheived by streaming AAC-encoded audio within [HLS](https://developer.apple.com/streaming/) segments. 
 
 ## Getting Started
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See the [deployment](#deployment) section for notes on how to deploy the project on a live system like [live.orcasound.net](https://live.orcasound.net).
+These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See the [deployment section](#deployment) for notes on how to deploy the project on a live system like [live.orcasound.net](https://live.orcasound.net).
 
 If you want to set up your hardware to host a hydrophone within the Orcasound network, take a look at [how to join Orcasound](http://www.orcasound.net/join/) and [our prototype built from a Raspberry Pi with the Pisound ADC HAT](http://www.orcasound.net/2018/04/27/orcasounds-new-live-audio-solution-from-hydrophone-to-headphone-with-a-raspberry-pi-computer-and-hls-dash-streaming-software/).
 
@@ -76,7 +76,7 @@ Here are explanations of some of the `.env` fields:
 
 ## Running local tests
 
-In the `node` directory (where you also put your .env file) first copy the compose file you want to `docker-compose.yml`.  For example, if you have a raspberry pi and you want to use the prebuilt image then copy `docker-compose.rpi-pull.yml` to `docker-compose.yml`.  Then run `docker-compose up -d`. Watch what happens using `htop`. If you want to verify files are being written to the `/tmp` or `/mnt` directories, get the name of your streaming service using `docker-compose ps` (in this case `orcanode_streaming_1`) and then do `docker exec -it orcanode_streaming_1 /bin/bash` to get a bash shell within the running container.
+In the `node` directory (where you also put your .env file) first copy the compose file you want to `docker-compose.yml`.  For example, if you have a Raspberry Pi and you want to use the prebuilt image then copy `docker-compose.rpi-pull.yml` to `docker-compose.yml`.  Then run `docker-compose up -d`. Watch what happens using `htop`. If you want to verify files are being written to the `/tmp` or `/mnt` directories, get the name of your streaming service using `docker-compose ps` (in this case `orcanode_streaming_1`) and then do `docker exec -it orcanode_streaming_1 /bin/bash` to get a bash shell within the running container.
 
 ## Running an end-to-end test
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ An Arm or x86 device with a sound card (or other audio input device) connected t
 
 ### Installing
 
-Create a base docker image for your architecture by running the script in `orcanode/base/rpi` or `orcanode/base/amd64` as appropriate.  You will need to create a `orcanode/node/.env` file as appropriate for your projects.  Common to to all projects is the need for AWS keys
+Create a base docker image for your architecture by running the script in `orcanode/base/rpi` or `orcanode/base/amd64` as appropriate.  You will need to create a `orcanode/node/.env` file as appropriate for your projects.  Common to all projects is the need for AWS keys
 
 ```
 AWSACCESSKEYID=YourAWSaccessKey
@@ -38,7 +38,7 @@ SYSLOG_URL=syslog+tls://syslog-a.logdna.com:YourLogDNAPort
 SYSLOG_STRUCTURED_DATA='logdna@YourLogDNAnumber key="YourLogDNAKey" tag="docker"
 ```
 
-(You can request keys via the [#hydrophone-nodes channel in the Orcasound Zulip](https://orcasound.zulipchat.com/#narrow/channel/437036-hydrophone-nodes). As of October, 2024, we are continuing to use AWS S3 for storage and Mezmo for live-logging and troubleshooting.)
+(You can request keys via the [#hydrophone-nodes channel in the Orcasound Zulip](https://orcasound.zulipchat.com/#narrow/channel/437036-hydrophone-nodes). As of October 2024, we are continuing to use AWS S3 for storage and Mezmo for live-logging and troubleshooting.)
 
 Here are explanations of some of the `.env` fields:
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The `orcanode` software repository contains audio tools and scripts for capturin
 
 There is a `base` set of tools and a couple of specific projects in the `node` and `mseed` directories. The `node` directory is for new locations streaming within the Orcasound listening network (primary nodes).
 
-The `mseed` directory has code for converting audio data in the mseed format to the live-streaming audio format used by primary nodes. This conversion code is mainly used for audio data collected by the [Ocean Observatories Initiative or OOI](https://oceanobservatories.org/ "OOI") network.  See the README in the `mseed` directory for more info. Transcoding from other audio formats should likely go in new directories by encoding scheme, similar to the mseed directory... 
+The `mseed` directory has code for converting audio data in the mseed format to the live-streaming audio format used by primary nodes. This conversion code is mainly used for audio data collected by the [Ocean Observatories Initiative or OOI](https://oceanobservatories.org/ "OOI") network.  See the README in the `mseed` directory for more info. Transcoding from other audio formats should likely go in new directories by encoding scheme, similar to the mseed directory.
 
 You can also gain some bioacoustic context for the project in the [orcanode wiki](https://github.com/orcasound/orcanode/wiki).
 
@@ -12,7 +12,7 @@ You can also gain some bioacoustic context for the project in the [orcanode wiki
 
 This code was developed for live-streaming from source nodes in the [Orcasound](http://orcasound.net) hydrophone network (WA, USA). Thus, the repository names begin with "orca"! Our primary motivation is to make it easy for community scientists to listen for whales via the [Orcasound web app](https://live.orcasound.net) using their favorite device/OS/browser.
 
-We also aspire to use open source software as much as possible. We rely heavily on [FFmpeg](https://www.ffmpeg.org/). One of our long-term goals is to stream lossless [FLAC](https://xiph.org/flac/)-encoded audio within [DASH](https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP) segments to a player that works optimally on as many listening devices as possible. For now (2018-2025) we have found the best end-to-end performance across the broadest range of web browsers is achieved by streaming AAC-encoded audio within [HLS](https://developer.apple.com/streaming/) segments. 
+We also aspire to use open-source software as much as possible. We rely heavily on [FFmpeg](https://www.ffmpeg.org/). One of our long-term goals is to stream lossless [FLAC](https://xiph.org/flac/)-encoded audio within [DASH](https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP) segments to a player that works optimally on as many listening devices as possible. For now (2018-2025) we have found the best end-to-end performance across the broadest range of web browsers is achieved by streaming AAC-encoded audio within [HLS](https://developer.apple.com/streaming/) segments. 
 
 ## Getting Started
 
@@ -28,7 +28,7 @@ An Arm or x86 device with a sound card (or other audio input device) connected t
 
 ### Installing
 
-Create a base docker image for your architecture by running the script in `orcanode/base/rpi` or `orcanode/base/amd64` as appropriate.  You will need to create a `orcanode/node/.env` file as appropriate for your projects.  Common to all projects is the need for AWS keys
+Create a base docker image for your architecture by running the script in `orcanode/base/rpi` or `orcanode/base/amd64` as appropriate.  You also will need to create an appropriate `orcanode/node/.env` file for your projects.  Common to all projects is the need for AWS keys
 
 ```
 AWSACCESSKEYID=YourAWSaccessKey
@@ -44,7 +44,7 @@ Here are explanations of some of the `.env` fields:
 
 * NODE_NAME should indicate your device and its location, ideally in the form `device_location` (e.g., we call our Raspberry Pi staging device in Seattle `rpi_seattle`). 
 * NODE_TYPE determines what audio data formats will be generated and transferred to their respective AWS buckets. 
-* AUDIO_HW_ID is the card, device providing the audio data. Note: you can find your sound device by using the command `arecord -l`.  For Raspberry Pi hardware with pisound just use `AUDIO_HW_ID=pisound`
+* AUDIO_HW_ID is the card, device providing the audio data. Note: you can find your sound device by using the command `arecord -l`.  For Raspberry Pi hardware with pisound, just use `AUDIO_HW_ID=pisound`
 * CHANNELS indicates the number of audio channels to expect (1 or 2). 
 * FLAC_DURATION is the amount of seconds you want in each archived lossless file. 
 * SEGMENT_DURATION is the amount of seconds you want in each streamed lossy segment.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ SYSLOG_STRUCTURED_DATA='logdna@YourLogDNAnumber key="YourLogDNAKey" tag="docker"
 
 Here are explanations of some of the `.env` fields:
 
-* NODE_NAME should indicate your device and it's location, ideally in the form `device_location` (e.g., we call our Raspberry Pi staging device in Seattle `rpi_seattle`. 
+* NODE_NAME should indicate your device and it's location, ideally in the form `device_location` (e.g., we call our Raspberry Pi staging device in Seattle `rpi_seattle`). 
 * NODE_TYPE determines what audio data formats will be generated and transferred to their respective AWS buckets. 
-* AUDIO_HW_ID is the card, device providing the audio data. Note: you can find your sound device by using the command `arecord -l`.  For Raspberry Pi hardware with pisound just use AUDIO_HW_ID=pisound
+* AUDIO_HW_ID is the card, device providing the audio data. Note: you can find your sound device by using the command `arecord -l`.  For Raspberry Pi hardware with pisound just use `AUDIO_HW_ID=pisound`
 * CHANNELS indicates the number of audio channels to expect (1 or 2). 
 * FLAC_DURATION is the amount of seconds you want in each archived lossless file. 
 * SEGMENT_DURATION is the amount of seconds you want in each streamed lossy segment.
@@ -76,7 +76,7 @@ Here are explanations of some of the `.env` fields:
 
 ## Running local tests
 
-In the `node` directory (where you also put your .env file) first copy the compose file you want to `docker-compose.yml`.  For example, if you have a Raspberry Pi and you want to use the prebuilt image then copy `docker-compose.rpi-pull.yml` to `docker-compose.yml`.  Then run `docker-compose up -d`. Watch what happens using `htop`. If you want to verify files are being written to the `/tmp` or `/mnt` directories, get the name of your streaming service using `docker-compose ps` (in this case `orcanode_streaming_1`) and then do `docker exec -it orcanode_streaming_1 /bin/bash` to get a bash shell within the running container.
+In the `node` directory (where you also put your .env file) first copy the compose file you want to `docker-compose.yml`.  For example, if you have a Raspberry Pi and you want to use the prebuilt image, then copy `docker-compose.rpi-pull.yml` to `docker-compose.yml`.  Then run `docker-compose up -d`. Watch what happens using `htop`. If you want to verify files are being written to the `/tmp` or `/mnt` directories, get the name of your streaming service using `docker-compose ps` (in this case `orcanode_streaming_1`) and then do `docker exec -it orcanode_streaming_1 /bin/bash` to get a bash shell within the running container.
 
 ## Running an end-to-end test
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can also gain some bioacoustic context for the project in the [orcanode wiki
 
 This code was developed for live-streaming from source nodes in the [Orcasound](http://orcasound.net) hydrophone network (WA, USA). Thus, the repository names begin with "orca"! Our primary motivation is to make it easy for community scientists to listen for whales via the [Orcasound web app](https://live.orcasound.net) using their favorite device/OS/browser.
 
-We also aspire to use open source software as much as possible. We rely heavily on [FFmpeg](https://www.ffmpeg.org/). One of our long-term goals is to stream lossless [FLAC](https://xiph.org/flac/)-encoded audio within [DASH](https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP) segments to a player that works optimally on as many listening devices as possible. For now (2018-2025) we have found the best end-to-end performance across the broadest range of web browsers is acheived by streaming AAC-encoded audio within [HLS](https://developer.apple.com/streaming/) segments. 
+We also aspire to use open source software as much as possible. We rely heavily on [FFmpeg](https://www.ffmpeg.org/). One of our long-term goals is to stream lossless [FLAC](https://xiph.org/flac/)-encoded audio within [DASH](https://en.wikipedia.org/wiki/Dynamic_Adaptive_Streaming_over_HTTP) segments to a player that works optimally on as many listening devices as possible. For now (2018-2025) we have found the best end-to-end performance across the broadest range of web browsers is achieved by streaming AAC-encoded audio within [HLS](https://developer.apple.com/streaming/) segments. 
 
 ## Getting Started
 
@@ -42,7 +42,7 @@ SYSLOG_STRUCTURED_DATA='logdna@YourLogDNAnumber key="YourLogDNAKey" tag="docker"
 
 Here are explanations of some of the `.env` fields:
 
-* NODE_NAME should indicate your device and it's location, ideally in the form `device_location` (e.g., we call our Raspberry Pi staging device in Seattle `rpi_seattle`). 
+* NODE_NAME should indicate your device and its location, ideally in the form `device_location` (e.g., we call our Raspberry Pi staging device in Seattle `rpi_seattle`). 
 * NODE_TYPE determines what audio data formats will be generated and transferred to their respective AWS buckets. 
 * AUDIO_HW_ID is the card, device providing the audio data. Note: you can find your sound device by using the command `arecord -l`.  For Raspberry Pi hardware with pisound just use `AUDIO_HW_ID=pisound`
 * CHANNELS indicates the number of audio channels to expect (1 or 2). 


### PR DESCRIPTION
I did *not* fix the diagram to change "streaming-orcasound.net" to "audio-orcasound-net" since that file is not in this repository.  That change still has to be done by someone with write access to orcasound.net/img/orcasound-app.

Among other changes, are:
* Changed LogDNA to Mezmo
* Changed Slack to Zulip
* Change 2023 to 2024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced formatting and clarity in the README.md file.
	- Updated year for streaming performance to 2025.
	- Changed logging service reference from "LogDNA" to "Mezmo."
	- Adjusted device architecture description for consistency.
	- Clarified instructions regarding the Docker compose file location.
	- Updated general scheme for acquiring audio data to reflect 2024.
	- Made minor grammatical adjustments for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->